### PR TITLE
Upgrade build tooling to Node 24

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
       "devDependencies": {
         "@vitejs/plugin-react-swc": "^4.3.1",
         "vite": "^8.1.3"
+      },
+      "engines": {
+        "node": ">=24 <25"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "matchmaker",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=24 <25"
+  },
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",


### PR DESCRIPTION
## Summary
- use Node 24 for GitHub Actions
- use Node 24 for the Docker build stage
- declare Node 24 in package engines

## Validation
- npm ci
- npm run build
- ARM64 Docker image build